### PR TITLE
Improve conda env channel order

### DIFF
--- a/binny
+++ b/binny
@@ -134,7 +134,9 @@ else
           env_name=$(head -n 1 ${i} | cut -d' ' -f2)
           if [[ ${env_name} == 'mantis' ]]; then
             mantis_env=${i%.yaml}
-            echo "Loading mantis env from: ${mantis_env}"
+            if [[ -n  ${mantis_env_config_var} ]]; then
+              echo "Loading mantis env from: ${mantis_env}"
+            fi
             mantis_set='true'
           fi
         done

--- a/workflow/envs/fasta_processing.yaml
+++ b/workflow/envs/fasta_processing.yaml
@@ -1,7 +1,7 @@
 name: fasta_processing
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - seqkit=2.1.0

--- a/workflow/envs/mantis.yaml
+++ b/workflow/envs/mantis.yaml
@@ -1,7 +1,7 @@
 name: mantis
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - mantis_pfa=1.4.7

--- a/workflow/envs/mapping.yaml
+++ b/workflow/envs/mapping.yaml
@@ -1,7 +1,7 @@
 name: mapping
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - bcftools=1.9

--- a/workflow/envs/prokka.yaml
+++ b/workflow/envs/prokka.yaml
@@ -1,7 +1,7 @@
 name: prokka
 channels:
-  - bioconda
   - conda-forge
+  - bioconda
   - defaults
 dependencies:
   - prokka=1.14.6

--- a/workflow/scripts/binny_functions.py
+++ b/workflow/scripts/binny_functions.py
@@ -855,10 +855,6 @@ def downcast_pd_df(df):
 
 def get_initial_clusters(contig_df, cluster_alg, threads, include_depth, hdbscan_epsilon, hdbscan_min_samples,
                          dist_metric, marker_sets_graph, tigrfam2pfam_data_dict):
-
-    print("get_initial_clusters, contig_df['contig']:", len(contig_df['contig'].to_list()))
-    print("get_initial_clusters, contig_df['contig']:", len(set(contig_df['contig'].to_list())))
-
     if len(contig_df['contig'].to_list()) != len(set(contig_df['contig'].to_list())):
         raise Exception
 


### PR DESCRIPTION
Set `conda-forge` first in conda environment channel order to avoid rare `package X requires package Y, but none of the providers can be installed` error during environment setup
Minor fixes